### PR TITLE
Prevent page from jumping around when scrolling into view.

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -18,7 +18,7 @@ function App() {
     if (!activeSection) return;
     document
       .querySelector(`.legend-item-${activeSection}`)
-      ?.scrollIntoView({ block: "center" });
+      ?.scrollIntoView({ block: "nearest", inline: "start" });
   }, [activeSection]);
 
   return (
@@ -77,7 +77,7 @@ function App() {
               tooltipData.map((dataPoint) => (
                 <div
                   className={classNames(
-                    "flex items-center gap-2",
+                    "flex scroll-my-5 items-center gap-2",
                     `legend-item-${dataPoint.name}`
                   )}
                   key={dataPoint.name}


### PR DESCRIPTION
# Fixing an important issue that was still present in the video 

Hi there! 

I've created this PR to explain a bit about a bug that was still present when recording the video. I though it would be a waste of time te rerecord parts to explain it better, since I can also explain it in this PR. 

After finishing the video, I was implementing it in the fe.fyi website, and noticed the following behaviour: 

https://github.com/frontendfyi/chart-tooltip-animation/assets/2969573/23d92251-9a08-4a8d-8612-b006f9846a0d

## So what's happening here? 

When we run ```document.querySelector(`.legend-item-${activeSection}`)?.scrollIntoView({ block: "center" });```, the browser tries to center the tooltip's active element in the center of the div. But on top of that, it also tries to center it in the screen! In build in the video, we actually did NOT have any room to scroll, so this issue was never visible. But when there is room, this suddenly becomes an issue. 

## So we have fix this

And in order to fix this, I had to spend quite some time googling around. Because the default behaviour of `scrollIntoView()`, is that always scrolls both the parent but also the window into view. 

Another option would be to manually calculate the scroll position of the tooltip by getting the offset of the active item from the top, and using `tooltipScrollWrapper.scrollTo({top: distanceFromTopForActiveTooltipChild });`. 

However, I think `scrollIntoView()` is such a nice API – because you don't need to calculate the center position yourself – that I really wanted to keep this in. So, after Googling around a bit I found the following solution you see in this PR: 

```  
document
      .querySelector(`.legend-item-${activeSection}`)
      ?.scrollIntoView({ block: "nearest", inline: "start" });
```

Instead of using `center` for block (where block is the Y position), we're now using `nearest`. This lets the browser decide what position is the best to scroll to (the position that's the least amount of scroll). If we then add `inline: "start"` too (where inline is the X position), then this results in the window not scrolling at ALL because the tooltip is always in view. The only thing that now scrolls, is the tooltip wrapper! 👏

## But we still need to center the tooltip

We do however still need to center the tooltip's content. And that's what the second change in this PR is for. We've added `scroll-my-5` to every tooltip item. What that adds is `scroll-margin-top` and `scroll-margin-bottom`. These scroll margins, tell the browser that when it scrolls to this element, it should take this margin into account. So when it wants to scroll to the top of the element, it would still stay for example 20 pixels away from the top, because of the scroll margin. By adding this on both the top and the bottom, and because we only have a very narrow tooltip container, this results in the tooltip still centring it's contents! 🔥

## Hope this makes sense! 

Hope this change makes sense to you! Sorry for making this mistake and not being able to explain it in the video anymore. Feel free to comment with any questions or your favourite GIF here! 😁

